### PR TITLE
Fix access to registered game clock from other threads

### DIFF
--- a/src/UnityExtension.cs
+++ b/src/UnityExtension.cs
@@ -2,7 +2,6 @@
 using Oxide.Core.Unity.Plugins;
 using System;
 using System.Reflection;
-using UnityEngine;
 
 namespace Oxide.Core.Unity
 {
@@ -51,7 +50,7 @@ namespace Oxide.Core.Unity
         {
             Manager.RegisterPluginLoader(new UnityPluginLoader());
 
-            Interface.Oxide.RegisterEngineClock(() => Time.realtimeSinceStartup);
+            Interface.Oxide.RegisterEngineClock(() => UnityScript.RealtimeSinceStartup);
 
             // Register our MonoBehaviour
             UnityScript.Create();

--- a/src/UnityScript.cs
+++ b/src/UnityScript.cs
@@ -10,6 +10,8 @@ namespace Oxide.Core.Unity
     public class UnityScript : MonoBehaviour
     {
         public static GameObject Instance { get; private set; }
+        
+        public static float RealtimeSinceStartup { get; private set; }
 
         public static void Create()
         {
@@ -22,6 +24,8 @@ namespace Oxide.Core.Unity
 
         private void Awake()
         {
+            RealtimeSinceStartup = Time.realtimeSinceStartup;
+
             oxideMod = Interface.Oxide;
 
             EventInfo eventInfo = typeof(Application).GetEvent("logMessageReceived");
@@ -50,7 +54,12 @@ namespace Oxide.Core.Unity
             }
         }
 
-        private void Update() => oxideMod.OnFrame(Time.deltaTime);
+        private void Update()
+        {
+            RealtimeSinceStartup = Time.realtimeSinceStartup;
+
+            oxideMod.OnFrame(Time.deltaTime);
+        }
 
         private void OnDestroy()
         {


### PR DESCRIPTION
Replaces registered game clock with own copy of Time.realtimeSinceStartup to avoid unity exception which occurs when accessing the original from a different thread than the main thread